### PR TITLE
Validate cells and Placement methods

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -20,7 +20,7 @@ class Board
   end
   
   def valid_placement?(ship, placement_coordinates)
-    if ship.length != placement_coordinates.length && 
+    if ship.length != placement_coordinates.length
       false
     else true
     end

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -15,6 +15,10 @@ class Board
     end
   end
 
+  def valid_coordinate?(coordinate)
+    @cells.include?(coordinate)
+  end
+
 
 
 end

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -18,7 +18,14 @@ class Board
   def valid_coordinate?(coordinate)
     @cells.include?(coordinate)
   end
-
+  
+  def valid_placement?(ship, placement_coordinates)
+    if ship.length != placement_coordinates.length && 
+      false
+    else true
+    end
+   
+  end
 
 
 end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -19,4 +19,17 @@ RSpec.describe Board do
       expect(board.cells.length).to eq(16)
     end
   end
+
+  describe '#valid_coordinate?' do 
+    it 'can tell us if a corrdinate is on the board or not' do
+      board = Board.new
+
+      expect(board.valid_coordinate?("A1")).to eq(true)
+      expect(board.valid_coordinate?("D4")).to eq(true)
+      expect(board.valid_coordinate?("A5")).to eq(false)
+      expect(board.valid_coordinate?("E1")).to eq(false)
+      expect(board.valid_coordinate?("A22")).to eq(false)
+    end
+
+  end
 end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -30,6 +30,45 @@ RSpec.describe Board do
       expect(board.valid_coordinate?("E1")).to eq(false)
       expect(board.valid_coordinate?("A22")).to eq(false)
     end
+  end
 
+  describe '#valid_placement?' do
+    it "it can tell us if the ship's placement is valid where the coordinates in the array are the same length as the ship" do
+      board = Board.new
+      cruiser = Ship.new("Cruiser", 3)
+      submarine = Ship.new("Submarine", 2)
+      
+      expect(board.valid_placement?(cruiser, ["A1", "A2"])).to eq(false)
+      expect(board.valid_placement?(submarine, ["A2", "A3", "A4"])).to eq(false)
+      
+    end
+    it "can tell us if the ship's placement is valid where the coordinates are consecutive" do 
+      board = Board.new
+      cruiser = Ship.new("Cruiser", 3)
+      submarine = Ship.new("Submarine", 2)
+      
+      expect(board.valid_placement?(cruiser, ["A1", "A2", "A4"])).to eq(false)
+      expect(board.valid_placement?(submarine, ["A1", "C1"])).to eq(false)
+      expect(board.valid_placement?(cruiser, ["A3", "A2", "A1"])).to eq(false)
+      expect(board.valid_placement?(submarine, ["C1", "B1"])).to eq(false)
+    end
+    
+    it "can tell us if the ship's placement is valid - it will not allow placement to be diagonal" do
+      board = Board.new
+      cruiser = Ship.new("Cruiser", 3)
+      submarine = Ship.new("Submarine", 2)
+      
+      expect(board.valid_placement?(cruiser, ["A1", "B2", "C3"])).to eq(false)
+      expect(board.valid_placement?(submarine, ["C2", "D3"])).to eq(false)
+    end
+    
+    it "can tell us if the ship's placement is valid - a ship is valid if all previous checks pass => the array of coordinates is the same length of the ship, the coordinates are consecutive, and the coordinates are not diagonal" do 
+      board = Board.new
+      cruiser = Ship.new("Cruiser", 3)
+      submarine = Ship.new("Submarine", 2)
+      
+      expect(board.valid_placement?(submarine, ["A1", "A2"])).to eq(true)
+      expect(board.valid_placement?(cruiser, ["B1", "C1", "D1"])).to eq(true)
+    end
   end
 end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe Board do
     it "can contain many cells from the start" do
       board = Board.new
       expect(board.cells).not_to eq({})
-      # expect(board.cells).to have(16).things
+      # require 'pry';binding.pry
+      expect(board.cells.length).to eq(16)
     end
   end
 end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Board do
   describe '#valid_coordinate?' do 
     it 'can tell us if a corrdinate is on the board or not' do
       board = Board.new
-
+      
       expect(board.valid_coordinate?("A1")).to eq(true)
       expect(board.valid_coordinate?("D4")).to eq(true)
       expect(board.valid_coordinate?("A5")).to eq(false)
@@ -37,12 +37,13 @@ RSpec.describe Board do
       board = Board.new
       cruiser = Ship.new("Cruiser", 3)
       submarine = Ship.new("Submarine", 2)
-      
+
       expect(board.valid_placement?(cruiser, ["A1", "A2"])).to eq(false)
       expect(board.valid_placement?(submarine, ["A2", "A3", "A4"])).to eq(false)
       
     end
-    it "can tell us if the ship's placement is valid where the coordinates are consecutive" do 
+
+    xit "can tell us if the ship's placement is valid where the coordinates are consecutive" do 
       board = Board.new
       cruiser = Ship.new("Cruiser", 3)
       submarine = Ship.new("Submarine", 2)
@@ -53,7 +54,7 @@ RSpec.describe Board do
       expect(board.valid_placement?(submarine, ["C1", "B1"])).to eq(false)
     end
     
-    it "can tell us if the ship's placement is valid - it will not allow placement to be diagonal" do
+    xit "can tell us if the ship's placement is valid - it will not allow placement to be diagonal" do
       board = Board.new
       cruiser = Ship.new("Cruiser", 3)
       submarine = Ship.new("Submarine", 2)
@@ -62,7 +63,7 @@ RSpec.describe Board do
       expect(board.valid_placement?(submarine, ["C2", "D3"])).to eq(false)
     end
     
-    it "can tell us if the ship's placement is valid - a ship is valid if all previous checks pass => the array of coordinates is the same length of the ship, the coordinates are consecutive, and the coordinates are not diagonal" do 
+    xit "can tell us if the ship's placement is valid - a ship is valid if all previous checks pass => the array of coordinates is the same length of the ship, the coordinates are consecutive, and the coordinates are not diagonal" do 
       board = Board.new
       cruiser = Ship.new("Cruiser", 3)
       submarine = Ship.new("Submarine", 2)


### PR DESCRIPTION
This PR will: 
- adjust the test for the @cells hash length 
- add tests for the valide_coordinate method 
- add the valid_coordinate? method 
- add tests for the valid_placement? method 
- add the first part of the valid_placement? method to test if `ship.length != placement_coodinate.length
- wip: to test the consecutive test to ensure that the placement coordinates are consecutively placed. 

I'm having a hard time getting the consecutive method written here - this might be a good method to pair on/ research separately and come back together on it! 